### PR TITLE
Modificaciones para el loading de usuarios en el dashboard de admin

### DIFF
--- a/src/main/java/com/tambo/tambo_delivery_backend/auth/config/WebSecurityConfig.java
+++ b/src/main/java/com/tambo/tambo_delivery_backend/auth/config/WebSecurityConfig.java
@@ -9,7 +9,6 @@ import org.springframework.security.authentication.dao.DaoAuthenticationProvider
 import static org.springframework.security.config.Customizer.withDefaults;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.factory.PasswordEncoderFactories;
@@ -44,11 +43,11 @@ public class WebSecurityConfig {
 
                                 .csrf(AbstractHttpConfigurer::disable)
                                 .authorizeHttpRequests((authorize) -> authorize
-                                                // Endpoints públicos
-                                                .requestMatchers("/api/auth/**", "/oauth2", "/api/public/**", "/api/dev/**")
-                                                .permitAll()
-                                                // Endpoints solo para ADMIN
+                                                // Endpoints solo para ADMIN (DEBE IR PRIMERO)
                                                 .requestMatchers("/api/admin/**").hasAuthority("ADMIN")
+                                                // Endpoints públicos
+                                                .requestMatchers("/api/auth/**", "/oauth2/**", "/api/public/**", "/api/dev/**")
+                                                .permitAll()
                                                 // Todos los demás endpoints requieren autenticación
                                                 .anyRequest().authenticated())
                                 .exceptionHandling(exception -> exception
@@ -61,16 +60,8 @@ public class WebSecurityConfig {
                 return http.build();
         }
 
-        // Rutas públicas que no reuieren autenticación
-        private static final String[] publicApis = {
-                        "/api/auth/**", "/api/public/**"
-        };
-
-        // Excluye completamente las rutas públicas del sistema de seguridad
-        @Bean
-        public WebSecurityCustomizer webSecurityCustomizer() {
-                return (web) -> web.ignoring().requestMatchers(publicApis);
-        }
+        // Nota: Las rutas públicas se manejan directamente en SecurityFilterChain
+        // No necesitamos WebSecurityCustomizer ya que SecurityFilterChain maneja todo
 
         // Configura el proveedor de autenticación con:
         // UserDetailsService (para cargar usuarios)

--- a/src/main/java/com/tambo/tambo_delivery_backend/auth/controllers/UserDetailController.java
+++ b/src/main/java/com/tambo/tambo_delivery_backend/auth/controllers/UserDetailController.java
@@ -1,5 +1,21 @@
 package com.tambo.tambo_delivery_backend.auth.controllers;
 
+import java.security.Principal;
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
 import com.tambo.tambo_delivery_backend.auth.dto.UserDetailsDto;
 import com.tambo.tambo_delivery_backend.auth.dto.UserResponseDto;
 import com.tambo.tambo_delivery_backend.auth.dto.UserUpdateDto;
@@ -10,24 +26,6 @@ import com.tambo.tambo_delivery_backend.dto.OrderDetails;
 import com.tambo.tambo_delivery_backend.entities.OrderStatus;
 import com.tambo.tambo_delivery_backend.services.AddressService;
 import com.tambo.tambo_delivery_backend.services.OrderService;
-
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.userdetails.UserDetailsService;
-import org.springframework.web.bind.annotation.CrossOrigin;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
-
-import java.security.Principal;
-import java.util.List;
-import java.util.UUID;
-
-import org.springframework.web.bind.annotation.PostMapping;
 
 // Proporcionar un endpoint seguro para que los usuarios autenticados obtengan su información de perfil
 @RestController
@@ -65,6 +63,7 @@ public class UserDetailController {
                                 .profileImageUrl(user.getProfileImageUrl())
                                 .email(user.getEmail())
                                 .phoneNumber(user.getPhoneNumber())
+                                .enabled(user.isEnabled())
                                 .authorityList(user.getAuthorities().stream()
                                                 .map(auth -> auth.getAuthority()).toList())
                                 .build();

--- a/src/main/java/com/tambo/tambo_delivery_backend/auth/dto/UserDetailsDto.java
+++ b/src/main/java/com/tambo/tambo_delivery_backend/auth/dto/UserDetailsDto.java
@@ -1,11 +1,11 @@
 package com.tambo.tambo_delivery_backend.auth.dto;
 
+import java.util.List;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-
-import java.util.List;
 
 @Data
 @Builder
@@ -18,5 +18,6 @@ public class UserDetailsDto {
     private String profileImageUrl;
     private String phoneNumber;
     private String email;
+    private Boolean enabled;
     private List<String> authorityList;
 }

--- a/src/main/java/com/tambo/tambo_delivery_backend/auth/helper/AuthorityDataLoader.java
+++ b/src/main/java/com/tambo/tambo_delivery_backend/auth/helper/AuthorityDataLoader.java
@@ -1,9 +1,11 @@
 package com.tambo.tambo_delivery_backend.auth.helper;
 
-import jakarta.annotation.PostConstruct;
 import org.springframework.stereotype.Component;
+
 import com.tambo.tambo_delivery_backend.auth.entities.Authority;
 import com.tambo.tambo_delivery_backend.auth.repositories.AuthorityRepository;
+
+import jakarta.annotation.PostConstruct;
 
 @Component
 public class AuthorityDataLoader {
@@ -17,19 +19,19 @@ public class AuthorityDataLoader {
 
     // Crea roles básicos (ADMIN y USER) en la base de datos si no existen al
     // iniciar la aplicación
-    // @PostConstruct
-    // public void loadAuthorityData() {
-    // createAuthorityIfNotFound("ADMIN", "Administrador del sistema");
-    // createAuthorityIfNotFound("USER", "Usuario estándar");
-    // }
+    @PostConstruct
+    public void loadAuthorityData() {
+        createAuthorityIfNotFound("ADMIN", "Administrador del sistema");
+        createAuthorityIfNotFound("USER", "Usuario estándar");
+    }
 
-    // private void createAuthorityIfNotFound(String roleCode, String description) {
-    // if (!authorityRepository.existsByRoleCode(roleCode)) {
-    // Authority authority = Authority.builder()
-    // .roleCode(roleCode)
-    // .roleDescription(description)
-    // .build();
-    // authorityRepository.save(authority);
-    // }
-    // }
+    private void createAuthorityIfNotFound(String roleCode, String description) {
+        if (!authorityRepository.existsByRoleCode(roleCode)) {
+            Authority authority = Authority.builder()
+                    .roleCode(roleCode)
+                    .roleDescription(description)
+                    .build();
+            authorityRepository.save(authority);
+        }
+    }
 }

--- a/src/main/java/com/tambo/tambo_delivery_backend/auth/services/UserService.java
+++ b/src/main/java/com/tambo/tambo_delivery_backend/auth/services/UserService.java
@@ -1,5 +1,12 @@
 package com.tambo.tambo_delivery_backend.auth.services;
 
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ServerErrorException;
+
 import com.tambo.tambo_delivery_backend.auth.dto.RegistrationRequest;
 import com.tambo.tambo_delivery_backend.auth.dto.UserResponseDto;
 import com.tambo.tambo_delivery_backend.auth.dto.UserUpdateDto;
@@ -7,13 +14,6 @@ import com.tambo.tambo_delivery_backend.auth.entities.User;
 import com.tambo.tambo_delivery_backend.auth.helper.VerificationCodeGenerator;
 import com.tambo.tambo_delivery_backend.auth.repositories.UserDetailRepository;
 import com.tambo.tambo_delivery_backend.dto.UserRequestDtoAdmin;
-
-import java.util.List;
-
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.stereotype.Service;
-import org.springframework.web.server.ServerErrorException;
 
 @Service
 public class UserService {
@@ -224,7 +224,8 @@ public class UserService {
             user.setProfileImageUrl(request.getProfileImageUrl());
             user.setPhoneNumber(request.getPhoneNumber());
             user.setEmail(request.getEmail());
-            user.setEnabled(true);
+            // Si el admin no especifica enabled, por defecto será true
+            user.setEnabled(request.getEnabled() != null ? request.getEnabled() : true);
             user.setPassword(passwordEncoder.encode("123456789"));
             user.setProvider("manual");
             user.setAuthorities(authorityService.getRequestedAuthorities(request.getRoles()));
@@ -248,7 +249,10 @@ public class UserService {
             user.setProfileImageUrl(request.getProfileImageUrl());
             user.setPhoneNumber(request.getPhoneNumber());
             user.setEmail(request.getEmail());
-            user.setEnabled(true);
+            // Permite al admin cambiar el estado enabled del usuario
+            if (request.getEnabled() != null) {
+                user.setEnabled(request.getEnabled());
+            }
             user.setAuthorities(authorityService.getRequestedAuthorities(request.getRoles()));
 
             User update = userDetailRepository.save(user);

--- a/src/main/java/com/tambo/tambo_delivery_backend/controllers/AdminController.java
+++ b/src/main/java/com/tambo/tambo_delivery_backend/controllers/AdminController.java
@@ -652,6 +652,7 @@ public class AdminController {
                     .email(u.getEmail().trim())
                     .profileImageUrl(u.getProfileImageUrl())
                     .phoneNumber(u.getPhoneNumber())
+                    .enabled(u.isEnabled())
                     .authorityList(u.getAuthorities().stream()
                             .map(auth -> auth.getAuthority()).toList())
                     .build()).toList();
@@ -678,6 +679,7 @@ public class AdminController {
                     .email(user.getEmail().trim())
                     .profileImageUrl(user.getProfileImageUrl())
                     .phoneNumber(user.getPhoneNumber())
+                    .enabled(user.isEnabled())
                     .authorityList(user.getAuthorities().stream()
                             .map(auth -> auth.getAuthority()).toList())
                     .build();

--- a/src/main/java/com/tambo/tambo_delivery_backend/dto/UserRequestDtoAdmin.java
+++ b/src/main/java/com/tambo/tambo_delivery_backend/dto/UserRequestDtoAdmin.java
@@ -12,6 +12,7 @@ public class UserRequestDtoAdmin {
     private String profileImageUrl;
     private String phoneNumber;
     private String email;
+    private Boolean enabled; // Permite al admin activar/desactivar usuarios
     private List<String> roles;
 
 }


### PR DESCRIPTION
1. Mejor ordenamiento del Spring Security empezando por los endpoints solo para admin, endpoints públicos y luego todo lo que requiere autenticación.
2. Se agregó el atributo 'Enable' a usuarios, para poder mostrarlo en el dashboard ('activo'), posteriormente se podrá inhabilitar o habilitar a los usuarios.
3. Se descomentó el inicializador automático de roles en AuthorityDataLoader, con el fin de:
- Garantiza que el sistema siempre tenga los roles básicos necesarios para funcionar
- Es idempotente: Se puede reiniciar la aplicación mil veces y no duplicará los roles (gracias al if (!authorityRepository.existsByRoleCode(roleCode)))
- Permite que el sistema funcione inmediatamente después de configurar la base de datos por primera vez